### PR TITLE
chore: update ui-connected to prevent crashing on logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@apollosproject/config": "^3.8.0",
     "@apollosproject/ui-analytics": "^3.8.0",
     "@apollosproject/ui-authentication": "^3.9.1-canary.11",
-    "@apollosproject/ui-connected": "^3.9.1-canary.9",
+    "@apollosproject/ui-connected": "^3.9.1-canary.23",
     "@apollosproject/ui-fragments": "^3.8.0",
     "@apollosproject/ui-htmlview": "^3.8.0",
     "@apollosproject/ui-kit": "^3.9.1-canary.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@
     react-native-url-polyfill "^1.3.0"
     yup "^0.27.0"
 
-"@apollosproject/ui-connected@^3.9.1-canary.9":
-  version "3.9.1-canary.9"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-connected/-/ui-connected-3.9.1-canary.9.tgz#2c0be878fb56bf45afaee0b664257253bd1b6ae5"
-  integrity sha512-B+YnRtrScqChvqlYMLsFzbyWsghWmuwuHAjFtosk5EP5ya3AH5OKTiOjW4i3iEinnIseZvVECHuX7ywdY64gnA==
+"@apollosproject/ui-connected@^3.9.1-canary.23":
+  version "3.9.1-canary.23"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-connected/-/ui-connected-3.9.1-canary.23.tgz#0c1a2bf64eb9e04e5403915dc22e023386ec0f3a"
+  integrity sha512-Yu4A2q0VvS7aHrQT4VqXttUcPd30kCq41k+u1dxsMHrVkWl3o8CuCCUAjCN4LMdqgO0z8u5W0Tx6N9eXMd6l+g==
   dependencies:
     "@gorhom/bottom-sheet" "3.4.1"
     "@react-navigation/bottom-tabs" "^5.11.8"


### PR DESCRIPTION
The purpose of this PR is to bump ui-connected to the latest canary release in order to fix a bug where the app crashes when a user tries to logout of their account.